### PR TITLE
Use itemid only if menu items are found

### DIFF
--- a/site/components/com_todo/router.php
+++ b/site/components/com_todo/router.php
@@ -30,7 +30,9 @@ function TodoBuildRoute(&$query)
 
         $items = JApplication::getInstance('site')->getMenu()->getItems($attributes, $values);
 
-        $query['Itemid'] = $items[0]->id;
+        if(count($items)) {
+            $query['Itemid'] = $items[0]->id;
+        }
 
     }
 


### PR DESCRIPTION
The lack of a check here produces an error if there is no menu item.